### PR TITLE
Provide the configured locale with the FE preview XML

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -32,6 +32,11 @@ yoast_seo_preview {
         30.field = description
         30.wrap = <description><![CDATA[|]]></description>
 
+        40 = TEXT
+        40.data = TSFE:config|config|locale_all
+        40.htmlSpecialChars = 1
+        40.wrap = <locale>|</locale>
+
         wrap = <meta>|</meta>
     }
 

--- a/Resources/Public/JavaScript/bundle.js
+++ b/Resources/Public/JavaScript/bundle.js
@@ -68,7 +68,8 @@ $.get(document.querySelector('[data-yoast-previewdataurl]').getAttribute('data-y
             saveContentScore: function (score) {
                 $('[data-controls="readability"]').find('.wpseo-score-icon').addClass(scoreToRating(score / 10));
             }
-        }
+        },
+        locale: $metaSection.find('locale').text()
     });
 
     app.refresh();

--- a/Resources/Public/JavaScript/plugin.js
+++ b/Resources/Public/JavaScript/plugin.js
@@ -67,7 +67,8 @@ $.get(document.querySelector('[data-yoast-previewdataurl]').getAttribute('data-y
             saveContentScore: function (score) {
                 $('[data-controls="readability"]').find('.wpseo-score-icon').addClass(scoreToRating(score / 10));
             }
-        }
+        },
+        locale: $metaSection.find('locale').text()
     });
 
     app.refresh();


### PR DESCRIPTION
The used locale is resolved from `config.locale_all`, the value can be modified from TypoScript and the integrator of the site is encouraged to do so properly.

Since there's no reliable method to resolve the used locale for the current page the value is rendered along with the preview XML.