### PR TITLE
Resolve translations JSON based on the language set by the user

### DIFF
--- a/Resources/Public/JavaScript/bundle.js
+++ b/Resources/Public/JavaScript/bundle.js
@@ -69,7 +69,8 @@ $.get(document.querySelector('[data-yoast-previewdataurl]').getAttribute('data-y
                 $('[data-controls="readability"]').find('.wpseo-score-icon').addClass(scoreToRating(score / 10));
             }
         },
-        locale: $metaSection.find('locale').text()
+        locale: $metaSection.find('locale').text(),
+        translations: (window.tx_yoast_seo !== undefined && window.tx_yoast_seo !== null && window.tx_yoast_seo.translations !== undefined ? window.tx_yoast_seo.translations : null)
     });
 
     app.refresh();

--- a/Resources/Public/JavaScript/plugin.js
+++ b/Resources/Public/JavaScript/plugin.js
@@ -68,7 +68,8 @@ $.get(document.querySelector('[data-yoast-previewdataurl]').getAttribute('data-y
                 $('[data-controls="readability"]').find('.wpseo-score-icon').addClass(scoreToRating(score / 10));
             }
         },
-        locale: $metaSection.find('locale').text()
+        locale: $metaSection.find('locale').text(),
+        translations: (window.tx_yoast_seo !== undefined && window.tx_yoast_seo !== null && window.tx_yoast_seo.translations !== undefined ? window.tx_yoast_seo.translations : null)
     });
 
     app.refresh();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -21,3 +21,54 @@ unset($pageMetaRenderer);
     '<INCLUDE_TYPOSCRIPT: source="FILE: EXT:yoast_seo/Configuration/TypoScript/setup.txt">',
     'defaultContentRendering'
 );
+
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['yoast_seo'] = array(
+    'translations' => array(
+        'availableLocales' => array(
+            'bg_BG',
+            'ca',
+            'da_DK',
+            'de_DE',
+            'en_AU',
+            'en_GB',
+            'es_ES',
+            'es_MX',
+            'fa_IR',
+            'fi',
+            'fr_FR',
+            'he_IL',
+            'hr',
+            'id_ID',
+            'it_IT',
+            'ja',
+            'nb_NO',
+            'nl_NL',
+            'pl_PL',
+            'pt_BR',
+            'pt_PT',
+            'ru_RU',
+            'sk_SK',
+            'sv_SE',
+            'tr_TR'
+        ),
+        'languageKeyToLocaleMapping' => array(
+            'bg' => 'bg_BG',
+            'da' => 'da_DK',
+            'de' => 'de_DE',
+            'en' => 'en_GB',
+            'es' => 'es_ES',
+            'fa' => 'fa_IR',
+            'fr' => 'fr_FR',
+            'he' => 'he_IL',
+            'it' => 'it_IT',
+            'no' => 'nb_NO',
+            'nl' => 'nl_NL',
+            'pl' => 'pl_PL',
+            'pt' => 'pt_PT',
+            'ru' => 'ru_RU',
+            'sk' => 'sk_SK',
+            'sv' => 'sv_SE',
+            'tr' => 'tr_TR'
+        )
+    )
+);


### PR DESCRIPTION
Respect the user setting `lang` when loading the YoastSEO app. Use a static mapping from language keys used by TYPO3 to locales used for YoastSEO translation files.